### PR TITLE
Remove NPM credentials

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
-//npm.fontawesome.com/:_authToken=12345678-2323-1111-1111-12345670B312
+//registry.npmjs.org/:_authToken=
+//npm.fontawesome.com/:_authToken=


### PR DESCRIPTION
This campaign removes NPM credentials across GitHub and Bitbucket Server.

---

Tokens found:

- [ ] `${NPM_TOKEN}`
- [ ] `12345678-2323-1111-1111-12345670B312`
