### PR TITLE
Rewrite fmt.Sprintf in Go code to strconv.Itoa

### DIFF
--- a/gopkg/main.go
+++ b/gopkg/main.go
@@ -13,6 +13,6 @@ func main() {
 		fmt.Println("match")
 	}
 
-	s := fmt.Sprintf("%d", 99)
+	s := strconv.Itoa(99)
 	fmt.Println(s)
 }


### PR DESCRIPTION
Rewrite `fmt.Sprintf` in Go code to `strconv.Itoa`

---

This pull request was created by a Sourcegraph campaign. [Click here to see the campaign](http://localhost:3080/campaigns/Q2FtcGFpZ246NA==).