### PR TITLE
Fix import path for log15 package

### DIFF
--- a/gopkg/logging.go
+++ b/gopkg/logging.go
@@ -1,6 +1,6 @@
 package main
 
-import "gopkg.in/inconshreveable/log15.v2"
+import "github.com/inconshreveable/log15"
 
 func LogWarn(msg string) {
 	log15.Warn(msg, "repository", "automation-testing")

--- a/gopkg/types.go
+++ b/gopkg/types.go
@@ -4,7 +4,7 @@ import (
 	"io"
 
 	"github.com/pkg/errors"
-	"gopkg.in/inconshreveable/log15.v2"
+	"github.com/inconshreveable/log15"
 )
 
 type Compiler struct {


### PR DESCRIPTION
Rewrites Go import paths for the `log15` package from `gopkg.in/inconshreveable/log15.v2` to `github.com/inconshreveable/log15` using [Comby](https://comby.dev/)