### PR TITLE
Replace fmt.Sprintf with equivalent strconv.Itoa

### DIFF
--- a/gopkg/main.go
+++ b/gopkg/main.go
@@ -13,6 +13,6 @@ func main() {
 		fmt.Println("match")
 	}
 
-	s := fmt.Sprintf("%d", 99)
+	s := strconv.Itoa(99)
 	fmt.Println(s)
 }


### PR DESCRIPTION
This campaign replaces `fmt.Sprintf` with `strconv.Itoa`