### PR TITLE
Replace fmt.Sprintf with much BETTER strconv.Itoa

### DIFF
--- a/gopkg/main.go
+++ b/gopkg/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 )
 
 func main() {
@@ -13,6 +14,6 @@ func main() {
 		fmt.Println("match")
 	}
 
-	s := fmt.Sprintf("%d", 99)
+	s := strconv.Itoa(99)
 	fmt.Println(s)
 }


### PR DESCRIPTION
This campaign replaces `fmt.Sprintf` with `strconv.Itoa`