### PR TITLE
Ignore editor temp files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Vim
+*.swp
+# JetBrains/IntelliJ
+.idea
+# Emacs
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+.\#*
+.dir-locals.el


### PR DESCRIPTION
This extends the .gitignore file to ignore temp files created by Vim/Emacs/IntelliJ

[_Created by Sourcegraph campaign `mrnugget-no-admin/gitignore-editor-files`._](https://sourcegraph.test:3443/users/mrnugget-no-admin/campaigns/gitignore-editor-files)