### PR TITLE
Add copyright notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ This repository is used to test opening and closing pull request with Automation
 (c) Copyright Sourcegraph 2013-2020.
 (c) Copyright Sourcegraph 2013-2020.
 (c) Copyright Sourcegraph 2013-2020.
+(c) Copyright Sourcegraph 2013-2020.

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,3 +6,4 @@ This folder contains examples
 
 (c) Copyright Sourcegraph 2013-2020.
 (c) Copyright Sourcegraph 2013-2020.
+(c) Copyright Sourcegraph 2013-2020.

--- a/examples/project3/README.md
+++ b/examples/project3/README.md
@@ -2,3 +2,4 @@
 
 (c) Copyright Sourcegraph 2013-2020.
 (c) Copyright Sourcegraph 2013-2020.
+(c) Copyright Sourcegraph 2013-2020.

--- a/project1/README.md
+++ b/project1/README.md
@@ -4,3 +4,4 @@ This is project 1.
 
 (c) Copyright Sourcegraph 2013-2020.
 (c) Copyright Sourcegraph 2013-2020.
+(c) Copyright Sourcegraph 2013-2020.

--- a/project2/README.md
+++ b/project2/README.md
@@ -1,3 +1,4 @@
 This is a starter template for [Learn Next.js](https://nextjs.org/learn).
 (c) Copyright Sourcegraph 2013-2020.
 (c) Copyright Sourcegraph 2013-2020.
+(c) Copyright Sourcegraph 2013-2020.


### PR DESCRIPTION
This repo was missing a copyright notice, fixing it here.

[_Created by Sourcegraph batch change `eseliger/add-copyright-notice`._](https://sourcegraph.test:3443/users/eseliger/batch-changes/add-copyright-notice)