### PR TITLE
Use new Docker Hub username in Circle CI config

### DIFF
--- a/circle-ci.yml
+++ b/circle-ci.yml
@@ -8,7 +8,7 @@ jobs:
     docker:
       - image: circleci/go:1.15
         auth:
-          username: mydockerhub-user
+          username: ci-dockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - checkout
@@ -17,7 +17,7 @@ jobs:
     docker:
       - image: circleci/go:1.15
         auth:
-          username: mydockerhub-user
+          username: ci-dockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - checkout

--- a/examples/circle-ci.yaml
+++ b/examples/circle-ci.yaml
@@ -8,7 +8,7 @@ jobs:
     docker:
       - image: circleci/go:1.15
         auth:
-          username: mydockerhub-user
+          username: ci-dockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - checkout
@@ -17,7 +17,7 @@ jobs:
     docker:
       - image: circleci/go:1.15
         auth:
-          username: mydockerhub-user
+          username: ci-dockerhub-user
           password: $DOCKERHUB_PASSWORD  # context / project UI env-var reference
     steps:
       - checkout


### PR DESCRIPTION
This change replaces the old Docker Hub user with the new, CI specific user account.

[_Created by Sourcegraph batch change `christine/circle-ci`._](https://demo.sourcegraph.com/users/christine/batch-changes/circle-ci)