### PR TITLE
Replace 'Copyright Sourcegraph 2013-2020' with 'Copyright Sourcegraph 2013-2026'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # automation-testing
 This repository is used to test opening and closing pull request with Automation
 
-(c) Copyright Sourcegraph 2013-2020.
-(c) Copyright Sourcegraph 2013-2020.
-(c) Copyright Sourcegraph 2013-2020.
+(c) Copyright Sourcegraph 2013-2026.
+(c) Copyright Sourcegraph 2013-2026.
+(c) Copyright Sourcegraph 2013-2026.

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,5 +4,5 @@ This folder contains examples
 
 (This is a test message, ignore)
 
-(c) Copyright Sourcegraph 2013-2020.
-(c) Copyright Sourcegraph 2013-2020.
+(c) Copyright Sourcegraph 2013-2026.
+(c) Copyright Sourcegraph 2013-2026.

--- a/examples/project3/README.md
+++ b/examples/project3/README.md
@@ -1,4 +1,4 @@
 # project3
 
-(c) Copyright Sourcegraph 2013-2020.
-(c) Copyright Sourcegraph 2013-2020.
+(c) Copyright Sourcegraph 2013-2026.
+(c) Copyright Sourcegraph 2013-2026.

--- a/project1/README.md
+++ b/project1/README.md
@@ -2,5 +2,5 @@
 
 This is project 1.
 
-(c) Copyright Sourcegraph 2013-2020.
-(c) Copyright Sourcegraph 2013-2020.
+(c) Copyright Sourcegraph 2013-2026.
+(c) Copyright Sourcegraph 2013-2026.

--- a/project2/README.md
+++ b/project2/README.md
@@ -1,3 +1,3 @@
 This is a starter template for [Learn Next.js](https://nextjs.org/learn).
-(c) Copyright Sourcegraph 2013-2020.
-(c) Copyright Sourcegraph 2013-2020.
+(c) Copyright Sourcegraph 2013-2026.
+(c) Copyright Sourcegraph 2013-2026.


### PR DESCRIPTION
This batch change replaces all occurrences of 'Copyright Sourcegraph 2013-2020' with 'Copyright Sourcegraph 2013-2026' in the matched files.

[_Created by Sourcegraph batch change `justin.dorfman/README-Copyright-update-2026`._](https://demo.sourcegraph.com/users/justin.dorfman/batch-changes/README-Copyright-update-2026)